### PR TITLE
Improve the interface to handling notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 hapi-stateless-notifications
 ============================
 
-A plugin to give a hapi `reply` a `reply.saveNotifications()` method that collects user notifications and store them long enough to display on later pages, given the token.
+A plugin to handle saving notifications to pass to a following page, so you can redirect after post and all those niceties without having to fall back to session-associated flash messages.
 
 Use
 -----
@@ -30,11 +30,29 @@ The `options` are optional.
 Then in a handler:
 
 ```
-request.saveNotifications([
+reply.saveNotifications([
     Promise.resolve('Success message here ...'),
     Promise.reject(new Error('Error message here ...')),
 ]).then(function (token) {
     // if there's a token, put it in the query of the page you load next as `notice={token}`
     // Otherwise, there's nothing to do.
 });
+```
+
+Or more completely:
+
+```
+reply.redirectAndNotify([
+    Promise.resolve('Success message here ...'),
+    Promise.reject(new Error('Error message here ...')),
+], '/next-page')
+```
+
+or if the failure path leads a different place:
+
+```
+reply.redirectAndNotify([
+    Promise.resolve('Success message here ...'),
+    Promise.reject(new Error('Error message here ...')),
+], { success: '/next-page', failure: '/this-page' })
 ```

--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
+"use strict";
+
 var P = require('bluebird');
 var TokenFacilitator = require('token-facilitator');
-var crypto = require('crypto');
 var debug = require('debuglog')('hapi-stateless-notifications');
+var url = require('url');
 
 exports.register = function(server, options, next) {
   options = options || {};
+
+  debug("Registering plugin");
 
   server.ext('onPreHandler', function(request, reply) {
 
@@ -21,6 +25,9 @@ exports.register = function(server, options, next) {
             type: 'success'
           });
         }).catch(function(error) {
+          if ((!error.statusCode && error.constructor != Error) || error.statusCode >= 500) {
+            throw error;
+          }
           debug("Error '%s' for request '%s'", error.message, request.id);
           return P.resolve({
             notice: error.message,

--- a/index.js
+++ b/index.js
@@ -47,9 +47,9 @@ exports.register = function(server, options, next) {
         });
       });
     })).then(function (notices) {
-      var anyFailed = Boolean(notices.find(function (n) {
+      var anyFailed = notices.some(function (n) {
         return n.type == 'error';
-      }));
+      });
 
       return putNoticesInRedis(self.request.redis, notices, options).then(function (token) {
         debug("Saved to redis for '%s' with token '%s'", self.request.id, token);
@@ -67,7 +67,6 @@ exports.register = function(server, options, next) {
 
     return this.saveNotifications(promises)
       .then(function (result) {
-        var target;
         if (typeof targetUrl == 'object') {
           targetUrl = targetUrl[result.success ? 'success' : 'failure'];
         }

--- a/index.js
+++ b/index.js
@@ -39,6 +39,26 @@ exports.register = function(server, options, next) {
     return reply.continue();
   });
 
+  server.decorate('reply', 'saveNotifications', function (promises) {
+    return this.request.saveNotifications(promises);
+  });
+
+  server.decorate('reply', 'redirectAndNotify', function (promises, targetUrl) {
+    promises = [].concat(promises);
+    var target = url.parse(targetUrl, true);
+    delete target.search; // url.parse and url.format are kind awful
+    var self = this;
+
+    return this.saveNotifications(promises)
+      .then(function (token) {
+        if (token) {
+          target.query.notice = token
+        }
+        self.redirect(url.format(target));
+      })
+  });
+
+
   server.ext('onPreResponse', function(request, reply) {
     if (request.query[options.queryParameter || 'notice']) {
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "hapi": "^15.2.0",
     "redis": "^2.5.3",
     "tap": "^8.0.0",
-    "vision": "^4.1.0"
+    "vision": "^4.1.0",
+    "with-fixtures": "^1.1.0"
   },
   "eslintConfig": {
     "parserOptions": {

--- a/test.js
+++ b/test.js
@@ -60,34 +60,33 @@ test('does it work?', t => {
         name: 'setup'
     };
 
-    server.register([
+    return server.register([
         Vision,
         setup,
         noticePlugin
-    ], () => {
-        server.views({
+    ])
+        .then(() => server.views({
             engines: {
                 hbs: require('handlebars')
             },
             relativeTo: __dirname,
             path: './test-templates',
             layoutPath: './test-templates'
-        });
-
-        server.inject({ method: 'GET', url: '/basic' }, res => {
+        }))
+        .then(() => server.inject({ method: 'GET', url: '/basic' }))
+        .then(res => {
             const token = res.result;
             t.ok(token);
-            server.inject({ method: "GET", url: '/fetch?notice=' + token}, res => {
-                const renderedNotices = res.result.trim().split('\n').map(value => value.trim())
-                t.equal(renderedNotices[0], 'success notice: yay');
-                t.equal(renderedNotices[1], 'error notice: boom');
-                t.equal(renderedNotices.length, 2);
-                server.stop();
-                client.quit();
-                t.end();
-            });
+            return server.inject({ method: "GET", url: '/fetch?notice=' + token})
+        })
+        .then(res => {
+            const renderedNotices = res.result.trim().split('\n').map(value => value.trim())
+            t.equal(renderedNotices[0], 'success notice: yay');
+            t.equal(renderedNotices[1], 'error notice: boom');
+            t.equal(renderedNotices.length, 2);
+            server.stop();
+            client.quit();
         });
-    });
 
 });
 

--- a/test.js
+++ b/test.js
@@ -15,7 +15,7 @@ test('does it work?', t => {
     server.route([
         {
             method: 'GET',
-            path: '/1',
+            path: '/basic',
             handler: (request, reply) => {
                 t.ok(request.saveNotifications, 'found method');
 
@@ -35,7 +35,7 @@ test('does it work?', t => {
         },
         {
             method: 'GET',
-            path: '/2',
+            path: '/fetch',
             handler: (request, reply) => {
                 t.ok(request.query.notice, 'got param');
                 reply.view('notices');
@@ -74,10 +74,10 @@ test('does it work?', t => {
             layoutPath: './test-templates'
         });
 
-        server.inject({ method: 'GET', url: '/1' }, res => {
+        server.inject({ method: 'GET', url: '/basic' }, res => {
             const token = res.result;
             t.ok(token);
-            server.inject({ method: "GET", url: '/2?notice=' + token}, res => {
+            server.inject({ method: "GET", url: '/fetch?notice=' + token}, res => {
                 const renderedNotices = res.result.trim().split('\n').map(value => value.trim())
                 t.equal(renderedNotices[0], 'success notice: yay');
                 t.equal(renderedNotices[1], 'error notice: boom');

--- a/test.js
+++ b/test.js
@@ -18,9 +18,9 @@ test('does it work?', t => {
             method: 'GET',
             path: '/basic',
             handler: (request, reply) => {
-                t.ok(request.saveNotifications, 'found method');
+                t.ok(reply.saveNotifications, 'found method');
 
-                request.saveNotifications([
+                reply.saveNotifications([
                     Promise.resolve('yay'),
                     Promise.reject(new Error('boom')),
                     Promise.reject(new Error('')),


### PR DESCRIPTION
- adds `reply.saveNotifications(promises)`
- adds `reply.redirectAndNotify(promises, url)`
- adds `reply.redirectAndNotify(promises, { success: url, failure: url })`

BREAKING CHANGE: will no longer pass through `TypeError` and other internal bug-indicating errors, nor 500 statusCode errors.