### PR TITLE
Handle regenerated requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,9 @@ exports.register = function(server, options, next) {
 
 
   server.ext('onPreResponse', function(request, reply) {
+    // Regenerated requests may not have these. Fail gracefully at least.
+    if (!request.logger || !request.redis) return reply.continue();
+
     if (request.query[options.queryParameter || 'notice']) {
 
       request.logger.info("checking for notices", request.query.notice);


### PR DESCRIPTION
This avoids a crash error and simply doesn't display the notice in
the case that it ends up displayed on a regenerated request, such
as an error or redirection to login screen